### PR TITLE
Serverless 0.5.x compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function(S) {
   class LambdaPrune extends S.classes.Plugin {
     constructor() {
       super();
+      this.name = 'prune';
     }
     static getName() {
       return 'net.nopik.' + LambdaPrune.name;

--- a/index.js
+++ b/index.js
@@ -9,14 +9,14 @@ module.exports = function(S) {
   BbPromise = require( 'bluebird' );
 
   class LambdaPrune extends S.classes.Plugin {
-    constructor(S) {
-      super(S);
+    constructor() {
+      super();
     }
     static getName() {
       return 'net.nopik.' + LambdaPrune.name;
     }
     registerActions() {
-      this.S.addAction(this.prune.bind(this), {
+      S.addAction(this.prune.bind(this), {
         handler:       'prune',
         description:   `Delete old/unused lambda versions from your AWS account`,
         context:       'function',
@@ -126,9 +126,9 @@ module.exports = function(S) {
     prune(evt) {
       let _this = this;
 
-      if (_this.S.cli) {
-        evt = JSON.parse(JSON.stringify(this.S.cli.options));
-        if (_this.S.cli.options.nonInteractive) _this.S._interactive = false
+      if (S.cli) {
+        evt = JSON.parse(JSON.stringify(S.cli.options));
+        if (S.cli.options.nonInteractive) S._interactive = false
       }
 
       _this.evt = evt;

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
-module.exports = function(SPlugin, serverlessPath) {
+module.exports = function(S) {
   const path = require( 'path' ),
-  SUtils = require( path.join( serverlessPath, 'utils' ) ),
-  context = require( path.join( serverlessPath, 'utils', 'context' ) ),
-  SCli = require( path.join( serverlessPath, 'utils', 'cli' ) ),
+  SUtils = require( S.getServerlessPath( 'utils' ) ),
+  context = require( S.getServerlessPath( 'utils/context' ) ),
+  SCli = require( S.getServerlessPath( 'utils/cli' ) ),
   AWS = require( 'aws-sdk' ),
   BbPromise = require( 'bluebird' );
 
-  class LambdaPrune extends SPlugin {
+  class LambdaPrune extends S.classes.Plugin {
     constructor(S) {
       super(S);
     }


### PR DESCRIPTION
Now `sls function prune` command got failure

```
TypeError: Path must be a string. Received undefined
```

---

I changed the plugin parameter format from

```
module.exports = function(SPlugin, serverlessPath) {
}
```

to

```
module.exports = function(S) {
}
```

And `sls function prune` works fine.
